### PR TITLE
Add hello world A2A agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ Open `index.html` in a browser to try it locally.
 4. After a minute, your site will be available at `https://<username>.github.io/<repository-name>/`.
 
 Replace `<username>` and `<repository-name>` with your GitHub username and repository name.
+
+## Running the example agent server
+
+A small Express server is included that exposes a `Hello World` A2A agent on port 3000. To start it locally:
+
+```bash
+npm install express cors
+node server.js
+```
+
+The marketplace page in `index.html` points at `http://localhost:3000/a2a` by default. Opening the page will automatically list the `Hello World Agent` which can be queried via the provided button.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "helloworld-agent",
+  "version": "1.0.0",
+  "description": "Example Hello World A2A agent server",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = 'https://example.com/a2a'; // Replace with your server URL
+const API_BASE_URL = 'http://localhost:3000/a2a';
 
 async function searchAgents() {
   const query = document.getElementById('search').value;
@@ -70,3 +70,4 @@ function buyAgent(agentId) {
     }
   });
 }
+document.addEventListener('DOMContentLoaded', searchAgents);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const cors = require('cors');
+const app = express();
+
+app.use(express.json());
+app.use(cors());
+
+// In-memory agent registry
+const agents = [
+  {
+    id: 'helloworld',
+    name: 'Hello World Agent',
+    description: 'Simple agent that responds with a greeting.',
+    endpoint: 'http://localhost:3000/helloworld'
+  }
+];
+
+// List agents, optional search
+app.get('/a2a/agents', (req, res) => {
+  const q = (req.query.search || '').toLowerCase();
+  const results = agents.filter(a => !q || a.name.toLowerCase().includes(q));
+  res.json(results);
+});
+
+// Register a new agent
+app.post('/a2a/agents', (req, res) => {
+  const { name, description, endpoint } = req.body;
+  if (!name || !endpoint) return res.status(400).json({ error: 'Missing fields' });
+  const id = name.toLowerCase().replace(/\s+/g, '-');
+  const agent = { id, name, description, endpoint };
+  agents.push(agent);
+  res.status(201).json(agent);
+});
+
+// Query an agent
+app.post('/a2a/agents/:id/query', (req, res) => {
+  const agent = agents.find(a => a.id === req.params.id);
+  if (!agent) return res.status(404).json({ error: 'Agent not found' });
+  const { query } = req.body;
+  // Simple hello world response
+  res.json({ answer: `Hello world! You asked: ${query}` });
+});
+
+// Simple hello world endpoint
+app.get('/helloworld', (req, res) => {
+  res.json({ message: 'Hello world!' });
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`A2A agent server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- set API base URL to local server
- auto-load agents when the page loads
- provide an Express server implementing a hello world A2A agent
- document how to run the sample server
- add a package.json for dependencies

## Testing
- `npm install`
- `node server.js` *(terminated after verifying startup)*
- `curl -s http://localhost:3000/a2a/agents`

------
https://chatgpt.com/codex/tasks/task_e_6870438d99ec832bb01c6e251b2b6272